### PR TITLE
Save environment file to target prefix

### DIFF
--- a/conda_declarative_input_states/state.py
+++ b/conda_declarative_input_states/state.py
@@ -14,7 +14,7 @@ def update_state(_command: str) -> None:
     _command : str
         Conda subcommand invoked by the user that triggered this call
     """
-    prefix = context.active_prefix
+    prefix = context.target_prefix
     env_yml = str(pathlib.Path(prefix) / "conda-meta" / "env.yml")
 
     packages = History(prefix=prefix).get_requested_specs_map()


### PR DESCRIPTION
Previously, the environment yaml would be saved to the `conda-meta` for the currently active prefix. Saving to the target_prefix instead would create a link between the environment file and the environment that produced this. 

So, now if you run something like:
```
$ conda create -n mytest python=3 --yes
. . .
  environment location: /home/sophia/envs/mytest
```

The `env.yaml` will be produced in the created environment's prefix.
```
$ cat /home/sophia/envs/mytest/conda-meta/env.yml 
name: mytest
dependencies:
  - python
prefix: /home/sophia/envs/mytest
```

And, you can use the `-n` and `-p` flags 
```
$ conda install -n mytest scipy  --yes

. . .

$ cat /home/sophia/envs/mytest/conda-meta/env.yml 
name: mytest
dependencies:
  - python
  - scipy
prefix: /home/sophia/envs/mytest
```